### PR TITLE
Support groovy ros distribution (only to host release metadata)

### DIFF
--- a/groovy.ignored
+++ b/groovy.ignored
@@ -1,0 +1,1 @@
+gazebo_ros_control

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -17,5 +17,25 @@ tracks:
     release_tag: :{version}
     ros_distro: hydro
     vcs_type: git
-    vcs_uri: https://github.com/osrf/gazebo_ros_pkgs.git
+    vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+    version: :{auto}
+  groovy:
+    actions:
+    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
+      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
+    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
+      --replace
+    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
+    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
+      -i :{release_inc}
+    devel_branch: null
+    last_version: 2.3.2
+    name: gazebo_ros_pkgs
+    patches: null
+    release_inc: '0'
+    release_repo_url: null
+    release_tag: :{version}
+    ros_distro: groovy
+    vcs_type: git
+    vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
     version: :{auto}


### PR DESCRIPTION
Although groovy target can not go into official ros repository, it helps our drcsim team to use the metadata to release our own packages for groovy used by drcsim. Seems a good idea to me to have all release metadata in the same repository.  

Groovy needs to ignore the gazebo_ros_control package via groovy.ignored since dependencies are not in this ros distro.
