### PR TITLE
Remove the ignore for gazebo_ros_control in Jade

### DIFF
--- a/jade.ignored
+++ b/jade.ignored
@@ -1,1 +1,0 @@
-gazebo_ros_control


### PR DESCRIPTION
By general consensus (@gerkey, @adolfo-rt, @scpeters): let's don't wait until the migration proposed at ros-simulation/gazebo_ros_pkgs#179 is finished. People has been reporting to use the code with catkin, so we don't any reason not to release that code into a binary.

//cc @davetcoleman, ros-simulation/gazebo_ros_pkgs#378