### PR TITLE
Include rosdistro in release-tags

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -1,66 +1,4 @@
 tracks:
-  groovy:
-    actions:
-    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
-      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
-    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
-      --replace
-    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
-    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
-      -i :{release_inc}
-    devel_branch: indigo-devel
-    last_version: 2.4.2
-    name: gazebo_ros_pkgs
-    patches: null
-    release_inc: '0'
-    release_repo_url: null
-    release_tag: :{version}
-    ros_distro: groovy
-    vcs_type: git
-    vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: :{auto}
-  hydro:
-    actions:
-    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
-      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
-    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
-      --replace
-    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
-    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
-      -i :{release_inc}
-    - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc}
-    devel_branch: hydro-devel
-    last_version: 2.3.8
-    name: gazebo_ros_pkgs
-    patches: null
-    release_inc: '0'
-    release_repo_url: null
-    release_tag: :{version}
-    ros_distro: hydro
-    vcs_type: git
-    vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: :{auto}
-  hydro-current:
-    actions:
-    - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
-      :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
-    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
-      --replace
-    - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
-    - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
-      -i :{release_inc}
-    devel_branch: indigo-devel
-    last_version: 2.4.2
-    name: gazebo_ros_pkgs
-    patches: null
-    release_inc: '0'
-    release_repo_url: null
-    release_tag: :{version}
-    ros_distro: hydro
-    vcs_type: git
-    vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
-    version: :{auto}
   indigo:
     actions:
     - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
@@ -80,7 +18,7 @@ tracks:
     patches: null
     release_inc: '0'
     release_repo_url: null
-    release_tag: :{version}
+    release_tag: :{version}_${ros_distro}
     ros_distro: indigo
     vcs_type: git
     vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
@@ -102,7 +40,7 @@ tracks:
     patches: null
     release_inc: '0'
     release_repo_url: null
-    release_tag: :{version}
+    release_tag: :{version}_${ros_distro}
     ros_distro: jade
     vcs_type: git
     vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
@@ -126,7 +64,7 @@ tracks:
     patches: null
     release_inc: '0'
     release_repo_url: null
-    release_tag: :{version}
+    release_tag: :{version}_${ros_distro}
     ros_distro: kinetic
     vcs_type: git
     vcs_uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git


### PR DESCRIPTION
In order to avoid tag conflicts between different ROS distributions using same versions (i.e. kinetic and jade using `2.4.6` at the same time). Extra ball: remove deprecated ROS distros.

Another option would be to include `${rosdistro}`in the version (i.e. `2.4.11~kinetic`) but I choose to only modified the tag for simplicity since I think that it will resolve the current conflict. A good effect of modifying versions could be to represent that code is, in fact, different even if the same version is used in different ROS distros.

May I have your feedback @scpeters @wjwwood? Thanks.